### PR TITLE
Make sure _initStore is called before query, etc

### DIFF
--- a/ArcGISServerStore.js
+++ b/ArcGISServerStore.js
@@ -19,7 +19,10 @@ define([
 	var _loadWrapper = function(callback, context) {
 		return function() {
 			var args = arguments;
-			return _loadDfd.then(function() {
+			return _loadDfd.then(function(res) {
+				if (!context._loaded) {
+					context._initStore(res);
+				}
 				return callback.apply(context, args);
 			});
 		};
@@ -31,7 +34,10 @@ define([
 			dfd.total = new Deferred();
 
 			var args = arguments;
-			_loadDfd.then(function() {
+			_loadDfd.then(function(res) {
+				if (!context._loaded) {
+					context._initStore(res);
+				}
 				try {
 					var callbackDfd = callback.apply(context, args);
 					callbackDfd.then(dfd.resolve, dfd.reject);
@@ -90,8 +96,6 @@ define([
 					},
 					handleAs: 'json',
 					callbackParamName: 'callback'
-				}).then(lang.hitch(this, '_initStore'), function(error) {
-					throw new Error('Invalid url. Cannot create store.');
 				});
 			} else {
 				throw new Error('Missing required property: \'url\'.');
@@ -104,13 +108,16 @@ define([
 			var remove = this.remove;
 			var query = this.query;
 
-			_loadDfd.then(lang.hitch(this, function() {
+			_loadDfd.then(lang.hitch(this, function(res) {
+				this._initStore(res);
 				this.get = get;
 				this.add = add;
 				this.put = put;
 				this.remove = remove;
 				this.query = query;
-			}));
+			})/*, function(error) {
+				throw new Error('Invalid url. Cannot create store.');
+			}*/);
 
 			this.get = _loadWrapper(this.get, this);
 			this.add = _loadWrapper(this.add, this);


### PR DESCRIPTION
In our app, we have multiple stores each pointing to a layer of a map service that is secured w/ token authentication. The first store that is initiated will trigger the IdentityManager to prompt the user for credentials. In the mean time, other stores try to initiate themselves but they get "token required" error responses from the server. Once the user supplies valid credentials, all stores are able to query as expected - but occasionally failed.

Unfortunately I have no been able to create a repeatable test case to demonstrate this outside of our app, but I was able to determine what was happening was that sometimes `_loadQueryWrapper`'s callback was being invoked before `_initStore` was called. My solution was to have the load wrappers check if the store has been loaded, and if not to call `_initStore` before they apply the callbacks.

I also removed error handler from loadDfd, as this was getting called for 'token required' responses that were later corrected once use logs in. I'm not sure if there area any consequences to this, and I'm open to reverting this, however, I think it might be better to raise the actual error ("token expired") instead of 'Invalid url. Cannot create store.'

Tests are passing, and this seems to correct issues in our app, but I welcome suggestions on better ways to accomplish this as I am sure you have a better understanding of the broader use cases.

cc @gavinr
