### PR TITLE
add `miniExclude` tag to build profile

### DIFF
--- a/profile.js
+++ b/profile.js
@@ -6,6 +6,9 @@ var profile = (function(){
             },
             amd: function(filename, mid) {
                 return /ArcGISServerStore\.js$/.test(filename) && !/tests/.test(filename);
+            },
+            miniExclude: function (filename, mid) {
+                return !/ArcGISServerStore\.js$/.test(filename) && !/LICENSE/.test(filename);
             }
         }
     };


### PR DESCRIPTION
Adds `miniExclude` tag to build profile, excluding all but the module and LICENSE.